### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
         "firebase": "^6.0.2",
         "get-json": "^1.0.1",
         "https-proxy-agent": "^2.2.1",
-        "npm": "^6.9.0",
         "parse-torrent-name": "^0.5.4",
         "react": "^16.8.6",
         "react-dom": "^16.8.6",


### PR DESCRIPTION

Hello carlelieser!

It seems like you have npm as one of your (dev-) dependency in Flixerr.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
